### PR TITLE
perf(file_server): hoistStatic and simplify operations

### DIFF
--- a/benchmarks/file_server/deno_serve.ts
+++ b/benchmarks/file_server/deno_serve.ts
@@ -1,24 +1,29 @@
 import { FILE_SERVER_PATH, HTTP_PORT, HTTP_URL } from "../SERVER_DATA.ts";
 import { getMimeType } from "https://deno.land/x/hono@v3.2.7/utils/mime.ts";
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { join } from "https://deno.land/std@0.192.0/path/mod.ts";
 
 export const NAME = "Deno.serve";
 export const DESCRIPTION = "";
 export const VERSION = "std 0.192.0";
 
+const body = {
+  status: 404,
+  statusText: "Not Found",
+};
+
+const base = join(Deno.cwd(), FILE_SERVER_PATH);
+
 if (import.meta.main) {
-  await Deno.serve({ hostname: HTTP_URL, port: HTTP_PORT }, (request: Request) => {
+  await Deno.serve({ hostname: HTTP_URL, port: HTTP_PORT }, async (request: Request) => {
     try {
-      const filePath = path.join(Deno.cwd(), FILE_SERVER_PATH, new URL(request.url).pathname);
-      const file = Deno.openSync(filePath);
+      const pathname = `/${request.url.split("/").pop()}`;
+      const filePath = join(base, pathname);
+      const file = await Deno.open(filePath);
       return new Response(file.readable, {
         headers: { "Content-Type": getMimeType(request.url)! },
       });
     } catch {
-      return new Response("Not Found", {
-        status: 404,
-        statusText: "Not Found",
-      });
+      return new Response(body.statusText, body);
     }
   }).finished;
 }

--- a/benchmarks/file_server/deno_serve_http.ts
+++ b/benchmarks/file_server/deno_serve_http.ts
@@ -1,10 +1,17 @@
 import { FILE_SERVER_PATH, HTTP_PORT, HTTP_URL } from "../SERVER_DATA.ts";
 import { getMimeType } from "https://deno.land/x/hono@v3.2.7/utils/mime.ts";
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import { join } from "https://deno.land/std@0.192.0/path/mod.ts";
 
 export const NAME = "Deno.serveHttp";
 export const DESCRIPTION = "";
 export const VERSION = `Deno ${Deno.version.deno}`;
+
+const body = {
+  status: 404,
+  statusText: "Not Found",
+};
+
+const base = join(Deno.cwd(), FILE_SERVER_PATH);
 
 if (import.meta.main) {
   for await (const conn of Deno.listen({ port: HTTP_PORT, hostname: HTTP_URL })) {
@@ -15,18 +22,16 @@ if (import.meta.main) {
 async function serveHttp(conn: Deno.Conn) {
   for await (const req of Deno.serveHttp(conn)) {
     try {
-      const filePath = path.join(Deno.cwd(), FILE_SERVER_PATH, new URL(req.request.url).pathname);
-      const file = Deno.openSync(filePath);
+      const pathname = `/${req.request.url.split("/").pop()}`;
+      const filePath = join(base, pathname)
+      const file = await Deno.open(filePath);
       const response = new Response(file.readable, {
         headers: { "Content-Type": getMimeType(req.request.url)! },
       });
       req.respondWith(response);
     } catch {
       req.respondWith(
-        new Response("Not Found", {
-          status: 404,
-          statusText: "Not Found",
-        }),
+        new Response(body.statusText, body),
       );
     }
   }

--- a/benchmarks/file_server/deno_serve_serveDir.ts
+++ b/benchmarks/file_server/deno_serve_serveDir.ts
@@ -5,9 +5,10 @@ export const NAME = "Deno.serve + serveDir from std";
 export const DESCRIPTION = "";
 export const VERSION = "std 0.192.0";
 
+const opts = {
+  fsRoot: FILE_SERVER_PATH,
+};
+
 if (import.meta.main) {
-  await Deno.serve({ hostname: HTTP_URL, port: HTTP_PORT }, (request) =>
-    serveDir(request, {
-      fsRoot: FILE_SERVER_PATH,
-    })).finished;
+  await Deno.serve({ hostname: HTTP_URL, port: HTTP_PORT }, (request) => serveDir(request, opts)).finished;
 }

--- a/benchmarks/file_server/deno_std_serve.ts
+++ b/benchmarks/file_server/deno_std_serve.ts
@@ -6,9 +6,10 @@ export const NAME = "std serve + serveDir";
 export const DESCRIPTION = "";
 export const VERSION = "0.192.0";
 
+const opts = {
+  fsRoot: FILE_SERVER_PATH,
+};
+
 if (import.meta.main) {
-  await serve((request) =>
-    serveDir(request, {
-      fsRoot: FILE_SERVER_PATH,
-    }), { hostname: HTTP_URL, port: HTTP_PORT });
+  await serve((request) => serveDir(request, opts), { hostname: HTTP_URL, port: HTTP_PORT });
 }

--- a/benchmarks/file_server/oak.ts
+++ b/benchmarks/file_server/oak.ts
@@ -5,14 +5,16 @@ export const NAME = "Oak";
 export const DESCRIPTION = "";
 export const VERSION = "12.5.0";
 
+const opts = {
+  root: FILE_SERVER_PATH,
+};
+
 if (import.meta.main) {
   const app = new Application();
 
   app.use(async (context, next) => {
     try {
-      await context.send({
-        root: FILE_SERVER_PATH,
-      });
+      await context.send(opts);
     } catch {
       await next();
     }


### PR DESCRIPTION
The file_server example has been optimized without unfairness。

Here is the performance of `file_server/deno_server.ts` before and after optimization 

## Before optimization

![deno_serve_before](https://github.com/Im-Beast/http_benchmarks/assets/36569518/c867f97e-2eb0-4ca9-b4df-7cb71d559034)

---

## After optimization
![deno_serve_after](https://github.com/Im-Beast/http_benchmarks/assets/36569518/69d96703-2958-4e49-84a7-2e000db2e88e)

Other examples have been more or less optimized.

Test data provided by [plow](https://github.com/six-ddc/plow)

Similar optimization tips in the community:

- [vitejs/vite/pull/12654](https://github.com/vitejs/vite/pull/12654)
- [vue-macros.sxzz.moe/features/hoist-static](https://[vue-macros.sxzz.moe/features/hoist-static.html](https://vue-macros.sxzz.moe/features/hoist-static.html))